### PR TITLE
feat: implement RISC-V CSR pseudo-instruction support

### DIFF
--- a/test/architectures/riscv32/test_cases.txt
+++ b/test/architectures/riscv32/test_cases.txt
@@ -58,6 +58,9 @@ b37d9d03  # 0  b3 7d 9d 03  remu s11, s10, s9
 f3155530  # 0  f3 15 55 30  csrrw        a1, mtvec, a0
 f3262634  # 0  f3 26 26 34  csrrs        a3, mcause, a2
 f33707c0  # 0  f3 37 07 c0  csrrc        a5, cycle, a4
+f3220318  # 0  f3 22 03 18  csrrs        t0, satp, t1
+f3120318  # 0  f3 12 03 18  csrrw        t0, satp, t1
+f3320318  # 0  f3 32 03 18  csrrc        t0, satp, t1
 73d85030  # 0  73 d8 50 30  csrrwi       a6, mtvec, 1
 f3682134  # 0  f3 68 21 34  csrrsi       a7, mcause, 2
 73f901c0  # 0  73 f9 01 c0  csrrci       s2, cycle, 3

--- a/test/architectures/riscv64/test_cases.txt
+++ b/test/architectures/riscv64/test_cases.txt
@@ -42,6 +42,9 @@ b3543901  # 0  b3 54 39 01  srl	s1, s2, s3
 b3503100  # 0  b3 50 31 00  srl	ra, sp, gp
 339f0f00  # 0  33 9f 0f 00  sll	t5, t6, zero
 # 731504b0  # 0  73 15 04 b0  csrrw	a0, mcycle, s0
+f3220318  # 0  f3 22 03 18  csrrs	t0, satp, t1
+f3120318  # 0  f3 12 03 18  csrrw	t0, satp, t1
+f3320318  # 0  f3 32 03 18  csrrc	t0, satp, t1
 f3560010  # 0  f3 56 00 10  csrrwi	a3, sstatus, 0
 33057b03  # 0  33 05 7b 03  mul	a0, s6, s7
 b3459c03  # 0  b3 45 9c 03  div	a1, s8, s9


### PR DESCRIPTION
- Implement csrr, csrw, csrc pseudo-instruction support
  - Automatically convert csrrs/csrrw/csrrc to pseudo-instructions when rs1=0
  - Ensure real instructions (rs1 != 0) are correctly displayed in full form
- Add real CSR instruction test cases
  - riscv64: csrrs/csrrw/csrrc t0, satp, t1
  - riscv32: csrrs/csrrw/csrrc t0, satp, t1
- Verify all CSR instructions (pseudo and real) are correctly distinguished and displayed