### PR TITLE
Fix rustdoc warnings

### DIFF
--- a/robustone-core/src/architecture.rs
+++ b/robustone-core/src/architecture.rs
@@ -439,7 +439,7 @@ impl Display for Architecture {
 impl From<&str> for Architecture {
     /// Performs the conversion from a string slice (`&str`) into `Architecture`.
     ///
-    /// This uses the same logic as [`Architecture::parse`].
+    /// This uses the same logic as `Architecture::parse`.
     ///
     /// # Examples
     ///
@@ -456,7 +456,7 @@ impl From<&str> for Architecture {
 impl From<String> for Architecture {
     /// Performs the conversion from a owned string (`String`) into `Architecture`.
     ///
-    /// This uses the same logic as [`Architecture::parse`].
+    /// This uses the same logic as `Architecture::parse`.
     fn from(name: String) -> Self {
         Architecture::parse(&name)
     }

--- a/robustone-core/src/utils/endian.rs
+++ b/robustone-core/src/utils/endian.rs
@@ -61,7 +61,7 @@ impl Endianness {
     ///
     /// # Returns
     ///
-    /// Returns a new Vec<u8> with the appropriate byte order applied.
+    /// Returns a new `Vec<u8>` with the appropriate byte order applied.
     pub fn apply_to_bytes(&self, bytes: &[u8]) -> Vec<u8> {
         match self {
             Endianness::Little => bytes.to_vec(),

--- a/robustone-isa/src/lib.rs
+++ b/robustone-isa/src/lib.rs
@@ -405,10 +405,10 @@ pub enum ImmExpr<F: Copy + Eq + 'static> {
     /// Compose an immediate from multiple non-contiguous bit fields.
     ///
     /// Used for:
-    /// - RISC-V B-type: imm[12|10:5|4:1|11] from bits [31],[30:25],[11:8],[7]
-    /// - RISC-V J-type: imm[20|10:1|11|19:12] from bits [31],[30:21],[20],[19:12]
-    /// - RISC-V S-type: imm[11:5|4:0] from bits [31:25],[11:7]
-    /// - LoongArch I26: disp[15:0|25:16] from bits [25:10],[9:0]
+    /// - RISC-V B-type: `imm[12|10:5|4:1|11]` from bits `[31]`, `[30:25]`, `[11:8]`, `[7]`
+    /// - RISC-V J-type: `imm[20|10:1|11|19:12]` from bits `[31]`, `[30:21]`, `[20]`, `[19:12]`
+    /// - RISC-V S-type: `imm[11:5|4:0]` from bits `[31:25]`, `[11:7]`
+    /// - LoongArch I26: `disp[15:0|25:16]` from bits `[25:10]`, `[9:0]`
     Compose {
         parts: &'static [ImmComposePart],
         transform: ImmediateTransform,


### PR DESCRIPTION
## Summary
  - Fix `robustone-core` rustdoc warnings by avoiding public documentation links to private items and quoting `Vec<u8>`.
  - Quote `robustone-isa` bit-field notation so rustdoc does not parse it as intra-doc links.

## Test Plan
- [x] `cargo doc --workspace --all-features --no-deps`
- [x] `cargo test --workspace --all-features`

Fix #57 